### PR TITLE
Add dep-dev

### DIFF
--- a/dep-dev/Dockerfile
+++ b/dep-dev/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:alpine
+
+# Create dep test user in abuild group. Make owner of /go, so that it can
+# install packages.
+RUN adduser -G abuild -g "dep test user" -s /bin/ash -D dep \
+      && echo "dep ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+      && chown -R dep:abuild /go/*
+
+# Install all the packages
+RUN apk update && apk add git gcc libc-dev bash mercurial \
+      && go get -v github.com/golang/dep \
+      && go get -v honnef.co/go/tools/cmd/gosimple \
+      && go get -v honnef.co/go/tools/cmd/staticcheck
+
+COPY ./runtest.sh /home/dep/runtest.sh
+
+WORKDIR /go/src/github.com/golang/dep
+
+ENTRYPOINT ["sh"]

--- a/dep-dev/Dockerfile
+++ b/dep-dev/Dockerfile
@@ -1,3 +1,12 @@
+# dep development in container
+#
+# docker run -ti --rm \
+#       -v $PWD:/go/src/github.com/golang/dep \
+#       dev-dep
+#
+# Run tests by passing "su dep -c "sh ~/runtest.sh" to the above command. It
+# runs the test commands as user dep.
+
 FROM golang:alpine
 
 # Create dep test user in abuild group. Make owner of /go, so that it can
@@ -7,8 +16,7 @@ RUN adduser -G abuild -g "dep test user" -s /bin/ash -D dep \
       && chown -R dep:abuild /go/*
 
 # Install all the packages
-RUN apk update && apk add git gcc libc-dev bash mercurial \
-      && go get -v github.com/golang/dep \
+RUN apk update && apk add git gcc libc-dev bash mercurial bzr \
       && go get -v honnef.co/go/tools/cmd/gosimple \
       && go get -v honnef.co/go/tools/cmd/staticcheck
 
@@ -16,4 +24,4 @@ COPY ./runtest.sh /home/dep/runtest.sh
 
 WORKDIR /go/src/github.com/golang/dep
 
-ENTRYPOINT ["sh"]
+CMD ["sh"]

--- a/dep-dev/README.md
+++ b/dep-dev/README.md
@@ -1,0 +1,5 @@
+dep-dev
+=======
+
+Container development environment for [dep](https://github.com/golang/dep) to
+build and run all the tests.

--- a/dep-dev/README.md
+++ b/dep-dev/README.md
@@ -3,3 +3,12 @@ dep-dev
 
 Container development environment for [dep](https://github.com/golang/dep) to
 build and run all the tests.
+
+```
+docker run -ti --rm \
+      -v $PWD:/go/src/github.com/golang/dep \
+      dev-dep
+```
+
+Run tests by passing "su dep -c "sh ~/runtest.sh" to the above command. It
+runs the test commands as user dep.

--- a/dep-dev/runtest.sh
+++ b/dep-dev/runtest.sh
@@ -1,0 +1,21 @@
+#/bin/sh
+
+cd /go/src/github.com/golang/dep
+
+PKGS=$(go list ./... | grep -v /vendor/ | grep -v _testdata/ )
+
+go build -v ./cmd/dep
+
+go vet $PKGS
+
+staticcheck $PKGS
+
+./hack/validate-vendor.bash
+
+gosimple $PKGS
+
+go build ./hack/licenseok
+
+set -e; for pkg in $PKGS; do go test -v $pkg; done
+
+./hack/validate-vendor.bash


### PR DESCRIPTION
- Adds dependency packages.
- Clones dep repo.
- Adds test user 'dep', unprivileged. Some tests in dep require an unprivileged
user to be running the tests, permission based tests.